### PR TITLE
Added backoff logic based on server-side TimeToEvaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Or to check health at a different interval (60 seconds in this case):
 ./bamboo-blinker https://your-bamboo.com/rest/build-bunny/1.0/summary/120edef1-a493-4813-82db-edb6b078cf6b.json 60
 ```
 
+## Backoff Logic
+To prevent dozens or hundreds of clients from beating up bamboo by checking too frequently, the application will double the delay interval up to 10 minutes when the returned timeToEvaluate > 150ms.  The interval will be reset to argument #2 (default 10s) as soon as the first response is within limits.
+
+To override the acceptable limit for this value, pass a 3rd argument.
+```
+./bamboo-blinker https://your-bamboo.com/rest/build-bunny/1.0/summary/120edef1-a493-4813-82db-edb6b078cf6b.json 60 200
+```
+
 ## Building
 
 This project depends on [goblync](https://github.com/davidehringer/goblync).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or to check health at a different interval (60 seconds in this case):
 ./bamboo-blinker https://your-bamboo.com/rest/build-bunny/1.0/summary/120edef1-a493-4813-82db-edb6b078cf6b.json 60
 ```
 
-## Backoff Logic
+### Backoff Logic
 To prevent dozens or hundreds of clients from beating up bamboo by checking too frequently, the application will double the delay interval up to 10 minutes when the returned timeToEvaluate > 150ms.  The interval will be reset to argument #2 (default 10s) as soon as the first response is within limits.
 
 To override the acceptable limit for this value, pass a 3rd argument.

--- a/bamboo-blinker.go
+++ b/bamboo-blinker.go
@@ -69,8 +69,9 @@ func main() {
 			}		
 			fmt.Printf("Interval increased to %d seconds since TimeToEvaluate was %d ms\n" , activeInterval,bunnyStatus.ProcessTime)
 		}else{
-			activeInterval = defaultInterval;
+
 			if(defaultInterval != activeInterval){
+				activeInterval = defaultInterval;
 				fmt.Printf("Interval reset to %d seconds since TimeToEvaluate was %d ms\n" , activeInterval,bunnyStatus.ProcessTime)
 			}			
 		}
@@ -104,7 +105,7 @@ func (m *monitor) SetHealthy() {
 			m.light.SetColor([3]byte{255 - byte(i), byte(i), 0x00})
 			time.Sleep(13 * time.Millisecond)
 		}
-		//m.light.Play(28)
+		m.light.Play(28)
 	}
 }
 
@@ -116,10 +117,10 @@ func (m *monitor) SetUnhealthy() {
 			time.Sleep(13 * time.Millisecond)
 		}
 		m.light.SetBlinkRate(blync.BlinkMedium)
-		//m.light.Play(52)
+		m.light.Play(52)
 		// We using a never ending sound because it was one of the only ones that 
 		// had some sound of urgency to it.  But we don't want it to keep playing
 		time.Sleep(time.Second * 15)
-		//m.light.StopPlay()
+		m.light.StopPlay()
 	}
 }

--- a/bunny/build-bunny.go
+++ b/bunny/build-bunny.go
@@ -16,37 +16,40 @@ type HttpBunny struct {
 	url string
 }
 
+type BunnyStatus struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	ProcessTime int `json:"timeToEvaluate"`
+}
+
 func NewBunny(url string) (bunny HttpBunny) {
 	bunny.url = url
 	return
 }
 
-func (bunny HttpBunny) Healthy() bool {
+
+func(bunny HttpBunny) Update() (bunnyStatus BunnyStatus) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
+
+
 	res, err := client.Get(bunny.url)
 	if err != nil {
 		fmt.Println(err)
-		return false
+		bunnyStatus.Status = "ERROR"
 	}
 	body, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		fmt.Println(err)
-		return false
+		bunnyStatus.Status = "ERROR"
+	}else{
+		json.Unmarshal(body, &bunnyStatus)
 	}
-
-	bunnyStatus := BunnyStatus{}
-	json.Unmarshal(body, &bunnyStatus)
-	if bunnyStatus.Status == "OK" {
-		return true
-	}
-	return false
+	//fmt.Println(string(body))
+	
+	return
 }
 
-type BunnyStatus struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-}


### PR DESCRIPTION
timeToEvaluate is set by bamboo plugin as an crude indicator of server load.  If the go app sees this climb above the configurable threshold it begins implementing an 2X increase on the interval up to a max. delay of 10 minutes.

PR includes code and readme updates.
